### PR TITLE
Ajout d'une section pour la config docker (wip) et pour la gestion des logs docker

### DIFF
--- a/05-Architecture des projets.md
+++ b/05-Architecture des projets.md
@@ -61,7 +61,67 @@ pour les dépôts Github, les fichiers de configuration ne sont pas versionnés 
 
 Les fichiers journaux de l’application doivent se situer dans un répertoire nomAppli/logs. Un fichier log4j.properties est fourni dans l’application pour déterminer la structure du fichier de log.
 
-## Bonnes pratiques
+## Configuration d'un projet avec docker
+
+Cette section est un **travail en cours** depuis début 2022 car la politique de développement évolue pour viser un packaging et un déploiement sur les environnements avec Docker à moyen terme.
+
+### Configuration d'une application docker
+
+TODO compléter les autres règles que l'on se donne, par exemple structure du dépôt git, Dockerfile multi-stage pour gérer la compilation, les tests et la génération des images prêtes à être déployées.
+
+### Configuration des logs des conteneurs dockers
+
+Chaque application qui est "dockerisée" et qui produit des logs (c'est à dire toutes les applis ?), doit les produire de la même façon et indiquer au démon filebeat comment les récupérer pour qu'il puisse ensuite les envoyer correctement au puits de log (logstash / elasticsearch / kibana).
+
+L'application doit respecter quelques règles :
+
+1) produire ses logs à surveiller sur stdout et stderr
+2) paramétrer filebeat avec des labels docker
+3) produire ses logs personnalisées en respectant un format
+
+#### stderr stdout
+
+Pour que le conteneur de l'application produise ses logs sur stdout et stderr, il y a plusieurs possibilités.
+  - Si c'est une application Java le mieux est d'exécuter le process java en premier plan (foreground). Exemple de point d'entrée docker exécutant l'appli java à partir d'un JAR en premier plan : ``ENTRYPOINT ["java","-jar","/app.jar"]``
+  - Si c'est une script shell (exemple un batch), alors on logguer sur stdout ou stderr au choix en utilisant ``>/dev/stdout`` (par défaut si rien n'est précisé c'est sur stdout que ça va) ou ``>/dev/stderr`` pour logguer les erreurs. Exemple :
+    ```bash
+    echo "INFO: ma ligne de log pour aller sur stdout" >/dev/stdout
+    echo "ERROR: ma ligne de log pour aller sur stderr" >/dev/stderr
+    ```
+  - Si c'est une application tierce qu'on ne peut donc pas trop modifier et qui loggue déjà dans un fichier, alors on peut soit configurer l'application pour lui demander de logguer les erreurs sur le fichier ``/proc/self/fd/2`` (c'est la même chose que le fichier ``/dev/stderr``) sur le fichier ``/proc/self/fd/1`` (ou au choix ``/dev/stdout``), soit identifier le chemin du fichier vers lequel l'application va logguer et s'en sortir avec un système de lien symbolique comme par exemple ce que l'image docker officielle de nginx fait : cf son [Dockerfile](https://github.com/nginxinc/docker-nginx/blob/8921999083def7ba43a06fabd5f80e4406651353/mainline/jessie/Dockerfile#L21-L23).
+  
+#### paramètres pour filebeat - labels docker
+
+Le paramétrage de la remontée des logs dans filebeat se fait au niveau de chaque conteneur en suivant une nomenclature de "labels docker" (cf [recommandations](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html#_customize_your_configuration)).
+
+La configuration la plus simple est de seulement signaler à filebeat que les logs du conteneur sont à prendre en compte en indiquant aucun format de log. Pour cela il est nécessaire d'ajouter les labels suivant au conteneur. Voici un extrait à copier coller dans un `docker-compose.yml` qui montre comment signaler à filebeat de prendre les logs en compte :
+```
+    labels:
+      - "co.elastic.logs/enabled=true"
+      - "co.elastic.logs/processors.add_fields.target="
+      - "co.elastic.logs/processors.add_fields.fields.abes_appli=monapplication"
+      - "co.elastic.logs/processors.add_fields.fields.abes_middleware=httpd"
+```
+
+Les labels ont la signification suivante :
+- `co.elastic.logs/enabled=true` : signifie qu'on souhaite que filebeat remonte les logs de ce conteneur (par défault c'est `false`)
+- `co.elastic.logs/processors.add_fields.target=` : signifie qu'on souhaite ajouter les deux champs `abes_appli` et `abes_middleware` dans le puits de logs en rateau à la racine des champs (cf [la doc](https://www.elastic.co/guide/en/beats/filebeat/current/add-fields.html#add-fields))
+- `co.elastic.logs/processors.add_fields.fields.abes_appli=monapplication` : signifie qu'on souhaite faire remonter un champs personnalisé nommé "abes_appli" qui contiendra comme valeur "monapplication" pour le conteneur présent. Ce champ "abes_appli" est obligatoire, il doit contenir le nom de l'application car cette dernière peut être éclatée en plusieurs conteneurs (un pour le web, un pour le back, un pour les batch etc ...), c'est ce champ qui permet de regrouper tous les conteneur d'une même application au niveau du puits de logs. Remarque : dans une architecture de type orchestrateur (ex: OKD), c'est probablement le nom du pod qui remplacera la valeur de "abes_appli".
+- `co.elastic.logs/processors.add_fields.fields.abes_middleware=Httpd` : le champs "abes_middleware" est obligatoire, il permet d'indiquer au puits de logs de l'Abes (via logstash précisément) la nature des logs envoyées et donc dans quel index elasticsearch doit il classer ces logs. Les valeurs possibles sont : "adhoc", "Httpd" (mettre "adhoc" si ce sont des logs dont le format est spécifique à l'application).
+
+Pour un exemple complet qui montre aussi comment spécifier un format de log précis, on peut se référer à https://github.com/abes-esr/abes-filebeat-docker/blob/f4b19dfdccab690801c550c61724bd09cbeb6f5b/docker-compose.yml#L24-L37
+
+On trouve alors d'autres labels dont voici la signification :
+- `co.elastic.logs/module=nginx` : signifie qu'on dit à filebeat que ce conteneur produit des logs au format nginx ce qui lui permettra de les envoyées découpées dans le puits de logs (cf la liste des [modules filebeat disponibles](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-modules.html))
+- `co.elastic.logs/fileset.stdout=access` : signifie que filebeat doit surveiller les logs stdout du conteneur
+- `co.elastic.logs/fileset.stderr=error` : signifie que filebeat doit surveiller les logs stderr du conteneur
+
+#### format pour les log personnalisées
+
+TODO expliquer ici que les appli java/métier doivent produire des logs spécifique en respectant certaines règles, lister les règles, donner des exemple de configuration de log4j etc ...
+
+
+## Bonnes pratiques de programmation
 
 En termes d'architecture, nous cherchons à privilégier : 
 


### PR DESCRIPTION
Ce n'est pas complet sur tout ce qu'on peut préconiser pour docker mais c'est un premier jet pour reverse la partie logs docker en lien avec filebeat qui était initialement en préparation ici : https://github.com/abes-esr/filebeat-example-docker#politique-de-dev